### PR TITLE
MV2-360: Adjust background in darkmode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.0.5 (06-05-2024)
+
+- fix wrong background of switch in darkmode
+
 ### 2.0.4 (02-05-2024)
 
 - adjust type export for switch component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2n/e2n-ui",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -45,7 +45,7 @@ const Switch = React.forwardRef<
       "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-main focus-visible:ring-offset-2 focus-visible:ring-offset-white",
       "disabled:cursor-not-allowed disabled:opacity-50",
       "data-[state=checked]:bg-primary-main data-[state=unchecked]:bg-slate-200",
-      "dark:focus-visible:ring-slate-300 dark:focus-visible:ring-offset-primary-main dark:data-[state=checked]:bg-slate-50 dark:data-[state=unchecked]:bg-primary-main",
+      "dark:focus-visible:ring-slate-300 dark:focus-visible:ring-offset-primary-main dark:data-[state=checked]:bg-slate-50 dark:data-[state=unchecked]:bg-primary-light",
       switchVariants({ size }),
       className
     )}


### PR DESCRIPTION
In diesem PR habe ich den Hintergrund vom Switch im Darkmode angepasst. Wir können es in Storybook leider noch nicht testen 🙈 @bluealf könntest du da trotzdem mal drüber schauen, ob das soweit passt?