### PR TITLE
Fix missing test-id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 2.0.6 (17-05-2024)
+
+- fix missing data-testid in switch component
+
 ### 2.0.5 (06-05-2024)
 
 - fix wrong background of switch in darkmode

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2n/e2n-ui",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/Switch/Switch.stories.tsx
+++ b/src/components/Switch/Switch.stories.tsx
@@ -9,7 +9,7 @@ export default {
 };
 
 export const Default: StoryObj<typeof Switch> = {
-  render: (args) => <Switch {...args} />,
+  render: (args) => <Switch {...args} data-testid="switch" />,
   args: {
     disabled: false,
     onCheckedChange: () => console.log("changed"),

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -50,7 +50,6 @@ const Switch = React.forwardRef<
       className
     )}
     {...props}
-    data-testid="switch"
     ref={ref}
   >
     <SwitchPrimitives.Thumb


### PR DESCRIPTION
Wir hatten das Problem das die `data-testid` beim Switch fälschlicherweise an der Komponente hartcodiert wurde. Das sollte jetzt soweit wieder passen. Version, Changelog + Story wurden entsprechend auch angepasst. @k-kaufmann @bluealf gerne nochmal drauf schauen ob das soweit passt