### PR TITLE
MV2-261: Kleinere Styleanpassungen + Export von Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### 4.1.1 (05-06-2024)
+
+- export types of Button and Input instead of interfaces
+- adjust style of Outline Button to old version of Outline Button
+- adjust height of Input
+- adjust space between Label and Input in Form component
+
 ### 4.1.0 (27-05-2024)
 
 - add Label Component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2n/e2n-ui",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -31,11 +31,10 @@ const buttonVariants = cva(
   },
 );
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
-}
+export type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean;
+  };
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -13,7 +13,7 @@ const buttonVariants = cva(
         secondary: 'bg-secondary-main text-white hover:bg-secondary-darker',
         destructive: 'bg-error-main text-white hover:bg-error-dark',
         outline:
-          'border border-input bg-white hover:bg-primary-8% text-primary-main',
+          'border border-primary-main bg-inherit hover:bg-primary-main hover:text-white text-primary-main',
         ghost: 'hover:bg-primary-8%',
         link: 'text-black underline-offset-4 hover:underline',
       },

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -25,12 +25,12 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           className={cn(
             'peer',
-            'flex h-9 w-full py-2',
+            'flex w-full py-2',
             `${startIcon ? 'ps-8' : 'ps-4'}`,
             `${endIcon ? 'pe-9' : 'pe-4'}`,
             'rounded-md border border-input',
-            'bg-transparent text-sm shadow-sm transition-colors',
-            'file:border-0 file:bg-transparent file:text-sm file:font-medium',
+            'bg-transparent text-md shadow-sm transition-colors leading-6',
+            'file:border-0 file:bg-transparent file:text-md file:font-medium',
             'placeholder:text-muted-foreground',
             'focus-visible:outline-none focus-visible:border-grey-500',
             'disabled:cursor-not-allowed disabled:opacity-50',

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -3,11 +3,10 @@ import { IconDefinition } from '@fortawesome/fontawesome-svg-core';
 import { cn } from '../../lib/utils';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-export interface InputProps
-  extends React.InputHTMLAttributes<HTMLInputElement> {
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement> & {
   startIcon?: IconDefinition;
   endIcon?: IconDefinition;
-}
+};
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, startIcon, endIcon, ...props }, ref) => {

--- a/src/form/Forms.tsx
+++ b/src/form/Forms.tsx
@@ -78,7 +78,7 @@ const FormItem = React.forwardRef<
 
   return (
     <FormItemContext.Provider value={{ id }}>
-      <div ref={ref} className={cn('space-y-2', className)} {...props} />
+      <div ref={ref} className={cn('space-y-1', className)} {...props} />
     </FormItemContext.Provider>
   );
 });


### PR DESCRIPTION
In diesem PR werden die Types von Button und Input exportiert, damit wir die Types bei der Verwendung zur Verfügungn haben. Anscheinend funktioniert das mit Interfaces nicht 🤔 

Zusätzlich gibt es ein paar kleinere Styleanpassungen von Input, Button und Form-Komponente, die mir beim Einbinden der Komponenten aufgefallen sind. Da wir teilweise alte und neue Inputs nebeneinander verwenden und die Höhe bzw. Abstand zwischen Label und Input nicht gleich ist, habe ich das mal angepasst, da mich das etwas getriggert hat 😅 