### PR TITLE
MV2-700

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 5.1.5 (26-07-2024)
+
+- adjust imports of Charts
+
 ### 5.1.4 (26-07-2024)
 
 - adjust imports of date-fns and popover

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2n/e2n-ui",
-  "version": "5.1.4",
+  "version": "5.1.5",
   "type": "module",
   "files": [
     "dist"

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -32,5 +32,6 @@ export * from './TextField';
 export * from './Tooltip';
 export * from './Label';
 export * from './Input';
+export * from './Charts';
 
 export * from './../legacy';

--- a/src/recharts/index.ts
+++ b/src/recharts/index.ts
@@ -1,1 +1,0 @@
-export * from 'recharts';

--- a/src/zod/index.ts
+++ b/src/zod/index.ts
@@ -1,1 +1,0 @@
-export * from 'zod';

--- a/yarn.lock
+++ b/yarn.lock
@@ -12023,17 +12023,17 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>":
   version: 5.4.2
-  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=d69c25"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/fcf6658073d07283910d9a0e04b1d5d0ebc822c04dbb7abdd74c3151c7aa92fcddbac7d799404e358197222006ccdc4c0db219d223d2ee4ccd9e2b01333b49be
+  checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
   version: 5.5.3
-  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=b45daf"
+  resolution: "typescript@patch:typescript@npm%3A5.5.3#optional!builtin<compat/typescript>::version=5.5.3&hash=d69c25"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver


### PR DESCRIPTION
entfernen von zod und recharts aus den exports
und hinzufügen der Charts komponenten zu den exports im `components` Folder