### PR TITLE
MV2-754

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -4,6 +4,7 @@ import { cn } from '../../lib/utils';
 import { buttonVariants, IconButton } from '../Button';
 import { faArrowLeft, faArrowRight } from '@fortawesome/free-solid-svg-icons';
 import { de } from 'date-fns/locale/de';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
@@ -55,10 +56,13 @@ function Calendar({
       }}
       components={{
         IconLeft: ({}) => (
-          <IconButton icon={faArrowLeft} className="h-4 w-4 border-none" />
+          <FontAwesomeIcon icon={faArrowLeft} className="h-4 w-4 border-none" />
         ),
         IconRight: ({}) => (
-          <IconButton icon={faArrowRight} className="h-4 w-4 border-none" />
+          <FontAwesomeIcon
+            icon={faArrowRight}
+            className="h-4 w-4 border-none"
+          />
         ),
       }}
       locale={de}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12075,21 +12075,21 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>":
   version: 5.4.2
-  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.4.2#optional!builtin<compat/typescript>::version=5.4.2&hash=d69c25"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/fcf6658073d07283910d9a0e04b1d5d0ebc822c04dbb7abdd74c3151c7aa92fcddbac7d799404e358197222006ccdc4c0db219d223d2ee4ccd9e2b01333b49be
+  checksum: 10c0/22e2f213c3ffe5960c5eaec6c95c04e01858fed57a94be250746f540b935b2c18c3c3fc80d3ab65d28c0aba1eb76284557ba3bf521d28caee811c44ba2b648f9
   languageName: node
   linkType: hard
 
 "typescript@patch:typescript@npm%3A^5.2.2#optional!builtin<compat/typescript>":
   version: 5.5.4
-  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=379a07"
+  resolution: "typescript@patch:typescript@npm%3A5.5.4#optional!builtin<compat/typescript>::version=5.5.4&hash=d69c25"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10c0/73409d7b9196a5a1217b3aaad929bf76294d3ce7d6e9766dd880ece296ee91cf7d7db6b16c6c6c630ee5096eccde726c0ef17c7dfa52b01a243e57ae1f09ef07
+  checksum: 10c0/10dd9881baba22763de859e8050d6cb6e2db854197495c6f1929b08d1eb2b2b00d0b5d9b0bcee8472f1c3f4a7ef6a5d7ebe0cfd703f853aa5ae465b8404bc1ba
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
In der Calendar.tsxt
Wurde für `IconRight` und `IconLeft` ein `IconButton` übergeben.
Dieser die eiden Icons werden aber schon vom `DayPicker` als Button gerendert wodurch es zu einer `<button><button></button></button>` Situation kam. 