### PR TITLE
Decrease bundle size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 10.0.2(10-10-2024)
+
+- react-dom shouldn't be bundled
+
 ### 10.0.1(02-10-2024)
 
 - Add badge component

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@e2n/e2n-ui",
-  "version": "10.0.1",
+  "version": "10.0.2",
   "type": "module",
   "files": [
     "dist"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,12 +16,13 @@ export default defineConfig({
     rollupOptions: {
       // make sure to externalize deps that shouldn't be bundled
       // into your library
-      external: ['react'],
+      external: ['react', 'react-dom'],
       output: {
         // Provide global variables to use in the UMD build
         // for externalized deps
         globals: {
           react: 'React',
+          'react-dom': 'ReactDOM',
         },
       },
     },


### PR DESCRIPTION
React Dom war ziemlich groß, manual chunks und globals kann man nicht zusammen setzen, habe es aber gesetzt um herauszufinden wo die große size her kommt. 
Denke es sollte so passen, dass mit beim nicht bundeln reinzunehmen, da wir react-dom schon im manager package haben.  